### PR TITLE
Relax version constraints for AWS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ module "vmseries" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.13, <0.15 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.10 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.7 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.10 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.7 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ resource "aws_network_interface" "this" {
 }
 
 resource "aws_eip" "this" {
-  for_each = { for k, v in var.interfaces : k => v if try(v.create_public_ip, false) && !can(v.eip_allocation_id) }
+  for_each = { for k, v in var.interfaces : k => v if try(v.create_public_ip, false) && ! can(v.eip_allocation_id) }
 
   vpc              = true
   public_ipv4_pool = try(each.value.public_ipv4_pool, "amazon")

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.10"
+      version = ">= 2.7"
     }
   }
 }


### PR DESCRIPTION
This module works with AWS provider version >= 2.7 and modifying the version constraint accordingly.